### PR TITLE
fix(demod): normalize upload PDU envelope

### DIFF
--- a/libs/demod/frame_monitor.cpp
+++ b/libs/demod/frame_monitor.cpp
@@ -185,7 +185,13 @@ void FrameMonitor::handle(const pmt::pmt_t& message, const char* path)
         recently_sent_.push_back({timestamp, payload});
         // Publish before formatting/logging: the first decoder branch to
         // complete a frame remains the minimum-latency proxy path.
-        message_port_pub(pmt::intern("out"), message);
+        // The uploader (packaging/payload/proxy/proxy_mmt_gui.exe) reads the
+        // frame from a hard-coded 10-byte offset into the serialized PMT and
+        // validates nothing.  That offset holds only for
+        // cons(PMT_NIL, u8vector), so a metadata car of any size corrupts
+        // every upload.  Normalise the envelope here, once, for every
+        // producer.
+        message_port_pub(pmt::intern("out"), pmt::cons(pmt::PMT_NIL, data));
         if (payload_callback_)
             payload_callback_(payload);
     } else {


### PR DESCRIPTION
## Summary

Every frame 1.5.2 publishes to the uploader is malformed on the wire. Uploads fail 100% of the time, for every session and every station. This restores the 1.5.0 wire format with a one-line change at the single point where a PDU reaches the `out` port.

## Root cause

The shipped uploader `packaging/payload/proxy/proxy_mmt_gui.exe` reads the CCSDS frame from a **hard-coded 10-byte offset** into the serialized PMT it receives on `tcp://127.0.0.1:5555`, then hex-dumps the remainder into the JSON field `raw_data`. Confirmed by disassembly — the `addl $0xa` / `subl $0xa` pair at `main+0xc74` drives both that loop and the ncurses "Raw Hex Data:" pane. There is no length check, no `0x1ACFFC1D` sync rescan, and no PMT parsing; the offset is trusted unconditionally.

That constant is correct only when the PDU's `car` is `PMT_NIL`:

| PDU shape | Serialized header | Total (223-byte frame) |
|---|---|---|
| `cons(PMT_NIL, u8vec(223))` | 10 bytes | 233 ✅ |
| `cons(dict{rs_corrected}, u8vec(223))` | 32 bytes | 255 ❌ |

Both remaining producers (`FecCandidateSink`, `OpenHoshimiDecoderSink`) attach a `dict{rs_corrected}` car, and `FrameMonitor::handle` republished the object verbatim. `raw_data` therefore arrived as 245 bytes: 22 bytes of PMT junk — beginning with the ASCII tail `orrected` — prefixed to the real 223-byte frame.

## Why 1.5.1 worked and 1.5.2 did not

The mechanism has been latent since 1.5.1. `OpenHoshimiDecoderSink` already emitted a dict car, wired straight to the upload path. It never mattered because `gr::lilacsat::fec_decode_b` publishes `pmt::cons(pmt::make_dict(), …)` — and `pmt::make_dict()` returns `PMT_NIL` — so a correctly-framed copy was always present alongside it.

1.5.2 swapped `fec_decode_b` for `FecCandidateSink`, removing the last NIL-car producer. Duplicate suppression then deleted the redundant good copies; that is an aggravator, not the cause. The uploader binary is byte-identical v1.5.1 → v1.5.2 and is not the regression.

## The change

`libs/demod/frame_monitor.cpp:188`:

```diff
-        message_port_pub(pmt::intern("out"), message);
+        message_port_pub(pmt::intern("out"), pmt::cons(pmt::PMT_NIL, data));
```

`data` is the `cdr` already extracted at the top of `handle()`, guarded by the existing `is_u8vector` early-return. `pmt::cons` allocates one pair and copies no payload bytes, so the publish-before-logging ordering that keeps the proxy path minimum-latency is preserved.

## Verification

The pipeline was reproduced natively: the repo's own vendored FEC chain (`ccsds.c`/`rs.c`/`viterbi27.c`, plain C) was compiled to decode **26 real CCSDS frames** from `recording.wav` (48 kHz mono Int16, 817 s). The real `FrameMonitor` was then run in a live GNU Radio 3.10.12 flowgraph — matching the project's `HYACINTHSAT_GR_310` target — patched and unpatched, capturing `pmt::serialize_str` output through a stub sink and slicing it with the uploader's exact `skip 10` logic.

| Build | Wire | `raw_data` | Frames matching truth |
|---|---|---|---|
| 1.5.0 — `fec_decode_b` → zmq direct | 233 B | 223 B | all |
| 1.5.1 — + OpenHoshimi, no dedup | 233 / 255 B | 223 / 245 B | mixed; good copy always present |
| 1.5.2 (HEAD) | 255 B | 245 B | **0 / 26** |
| **This PR** | **233 B** | **223 B** | **26 / 26** |

```
true frame    : 2050580effc008d2cb0e007f00413788c2dbdca9
1.5.2 raw_data: 6f727265637465640300000000060a00000000df   ascii: orrected....
fixed raw_data: 2050580effc008d2cb0e007f00413788c2dbdca9
```

Both builds reported `published 26 PDUs, suppressed 26 duplicates` when every frame was fed twice, confirming dedup is unaffected.

Three previously deduced claims are now measured: `pmt::make_dict()` is `PMT_NIL`; the NIL-car header is exactly 10 bytes (`07 06 0a 00 00 00 00 df 01 00`); the junk prefix is 22 bytes beginning with ASCII `orrected`.

No traffic was sent to `119.45.229.166` — no socket was opened at any point, and `pub_msg_sink` was never instantiated.