### PR TITLE
upload: restore telemetry frame publication

### DIFF
--- a/libs/demod/flowgraph.cpp
+++ b/libs/demod/flowgraph.cpp
@@ -581,8 +581,8 @@ void AsrtuFlowgraph::build(LogCallback callback, const Options& options)
             "TCP_SERVER", "127.0.0.1", "9985", 10000, false);
         char zmqAddress[] = "tcp://127.0.0.1:5555";
         const auto zmq = gr::zeromq::pub_msg_sink::make(zmqAddress, 1000, true);
-        tb_->msg_connect(frame_monitor_, "out", tcp, "pdus");
-        tb_->msg_connect(frame_monitor_, "out", zmq, "in");
+        tb_->msg_connect(frame_monitor_, "network", tcp, "pdus");
+        tb_->msg_connect(frame_monitor_, "network", zmq, "in");
     }
 }
 

--- a/libs/demod/frame_monitor.cpp
+++ b/libs/demod/frame_monitor.cpp
@@ -51,6 +51,7 @@ FrameMonitor::FrameMonitor(Callback callback, PayloadCallback payloadCallback,
         });
     }
     message_port_register_out(pmt::intern("out"));
+    message_port_register_out(pmt::intern("network"));
     candidate_worker_ = std::thread([this] { candidateWorker(); });
 }
 
@@ -173,6 +174,8 @@ void FrameMonitor::handle(const pmt::pmt_t& message, const char* path)
         parallel_frame_count_.fetch_add(1, std::memory_order_relaxed);
     else
         primary_frame_count_.fetch_add(1, std::memory_order_relaxed);
+
+    message_port_pub(pmt::intern("network"), message);
 
     while (!recently_sent_.empty() &&
            timestamp - recently_sent_.front().sent_ms > kDuplicateWindowMs) {


### PR DESCRIPTION
ASRTU 1.5.2 routes TCP and ZMQ output through FrameMonitor::out. That port also applies local duplicate suppression, so frames from parallel decoder branches can be discarded before reaching the upload proxy.

Add a separate FrameMonitor::network output and connect TCP/ZMQ publishing to it. Every successful FEC frame is now published immediately to the telemetry transport, while local UI and SSDV callbacks retain duplicate suppression.