### PR TITLE
fix(demod): normalize upload PDUs and fix GCC build

### DIFF
--- a/libs/demod/flowgraph.h
+++ b/libs/demod/flowgraph.h
@@ -53,7 +53,7 @@ public:
         FrameMonitor::PayloadCallback local_candidate_callback;
     };
 
-    explicit AsrtuFlowgraph(LogCallback callback, Options options = {});
+    AsrtuFlowgraph(LogCallback callback, Options options);
     ~AsrtuFlowgraph();
 
     void start();

--- a/libs/demod/frame_monitor.cpp
+++ b/libs/demod/frame_monitor.cpp
@@ -175,7 +175,12 @@ void FrameMonitor::handle(const pmt::pmt_t& message, const char* path)
     else
         primary_frame_count_.fetch_add(1, std::memory_order_relaxed);
 
-    message_port_pub(pmt::intern("network"), message);
+    // The uploader (packaging/payload/proxy/proxy_mmt_gui.exe) reads the frame
+    // from a hard-coded 10-byte offset into the serialized PMT and validates
+    // nothing.  That offset holds only for cons(PMT_NIL, u8vector), so a
+    // metadata car of any size corrupts every upload.  This is the port the
+    // TCP/ZMQ sinks are connected to, so the envelope must be normalised here.
+    message_port_pub(pmt::intern("network"), pmt::cons(pmt::PMT_NIL, data));
 
     while (!recently_sent_.empty() &&
            timestamp - recently_sent_.front().sent_ms > kDuplicateWindowMs) {
@@ -188,12 +193,8 @@ void FrameMonitor::handle(const pmt::pmt_t& message, const char* path)
         recently_sent_.push_back({timestamp, payload});
         // Publish before formatting/logging: the first decoder branch to
         // complete a frame remains the minimum-latency proxy path.
-        // The uploader (packaging/payload/proxy/proxy_mmt_gui.exe) reads the
-        // frame from a hard-coded 10-byte offset into the serialized PMT and
-        // validates nothing.  That offset holds only for
-        // cons(PMT_NIL, u8vector), so a metadata car of any size corrupts
-        // every upload.  Normalise the envelope here, once, for every
-        // producer.
+        // Normalised for the same reason as the "network" port above, so that
+        // re-pointing a transport at this port cannot reintroduce the bug.
         message_port_pub(pmt::intern("out"), pmt::cons(pmt::PMT_NIL, data));
         if (payload_callback_)
             payload_callback_(payload);


### PR DESCRIPTION
## Problem

`proxy_mmt_gui.exe` reads the CCSDS frame from a **hard-coded 10-byte offset** into the serialized PMT and validates nothing — no length check, no `0x1ACFFC1D` rescan, no PMT parsing (confirmed by `objdump`: the `addl $0xa` / `subl $0xa` pair at `main+0xc74`). That offset is correct only when the PDU's `car` is `PMT_NIL`.

Since 1.5.2 every producer attaches a `dict{rs_corrected}` car, which serializes to a 32-byte header instead of 10. `raw_data` therefore arrives as 245 bytes: 22 bytes of PMT junk — starting with the ASCII tail `orrected` — prefixed to the real 223-byte frame.

`#2` fixed this on `FrameMonitor::out`. `#3` then added a separate `network` port and moved the TCP/ZMQ sinks onto it — correct in itself, since dedup was discarding parallel-branch frames before upload, but it routed around the normalisation. The two merged cleanly and the bug came back.

## Changes

**`libs/demod/frame_monitor.cpp`** — normalise the envelope on the port the transports are actually connected to:

```diff
-    message_port_pub(pmt::intern("network"), message);
+    message_port_pub(pmt::intern("network"), pmt::cons(pmt::PMT_NIL, data));
```

`out` keeps its normalisation too, so re-pointing a transport at either port cannot reintroduce the bug. `data` is the `cdr` already extracted at the top of `handle()`; `pmt::cons` allocates one pair and copies no payload bytes.

`#3`'s behaviour is preserved — the upload path still publishes every frame before duplicate suppression. Producers, wiring, dedup, SSDV/UI callbacks and the `rs_corrected` debug log are unchanged.

**`libs/demod/flowgraph.h`** — drop an ill-formed default argument that blocks every non-MSVC build:

```diff
-    explicit AsrtuFlowgraph(LogCallback callback, Options options = {});
+    AsrtuFlowgraph(LogCallback callback, Options options);
```

`Options` is a nested class with default member initializers, which are not available in the enclosing class's complete-class context — so `Options options = {}` is ill-formed. MSVC accepts it; clang and gcc reject it and the build stops at the first two translation units. The default was unused: both call sites (`main_window.cpp:670`, `benchmark_main.cpp:81`) already pass `options` explicitly. Behaviour-neutral, and MSVC compiles the new form identically.

## Verification

The real `AsrtuFlowgraph` was run on an 817 s recording at 30× replay — real `FecCandidateSink` ×4, real `OpenHoshimiDecoderSink`, real `FrameMonitor`, real `gr::zeromq::pub_msg_sink` — with a passive SUB capturing the actual socket.

| | ZMQ msgs | wire | `raw_data` | valid frames |
|---|---|---|---|---|
| before | 75 | 255 B | 245 B | **0 / 75** |
| after | 75 | 233 B | 223 B | **75 / 75** |

```
before raw_data[:20]: 6f727265637465640300000000060a00000000df   ascii: orrected....
after  raw_data[:20]: 2050580effc008d2cb0e007f00413788c2dbdca9
```

Both runs reported identical decoder statistics — `frameCount=75 primary=26 parallel=49 suppressed=49`, 26 unique frames — so nothing but the envelope changed. No traffic reached the telemetry server: the proxy was never launched and all sockets were loopback.