### PR TITLE
decoder: harden frame arbitration and FEC state

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.20)
 project(ASRTU1Qt VERSION 1.5.3 LANGUAGES C CXX)
 
+include(CTest)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_AUTOMOC OFF)
@@ -217,20 +219,37 @@ if(MSVC)
     target_compile_options(ASRTU1_Benchmark PRIVATE /W4 /permissive- /utf-8)
 endif()
 
-add_executable(ASRTU1_SsdvTest
-    tests/ssdv_receiver_test.cpp
-    libs/demod/ssdv_receiver.cpp
-    libs/demod/ssdv_receiver.h)
-target_include_directories(ASRTU1_SsdvTest PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/libs/demod)
-target_link_libraries(ASRTU1_SsdvTest PRIVATE Qt5::Core Qt5::Gui ssdv_dslwp)
-target_compile_definitions(ASRTU1_SsdvTest PRIVATE
-    ASRTU_TEST_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/asrtu1_ssdv_capture.b64")
-if(MSVC)
-    target_compile_options(ASRTU1_SsdvTest PRIVATE /W4 /permissive- /utf-8)
 endif()
-enable_testing()
-add_test(NAME ssdv_receiver COMMAND ASRTU1_SsdvTest)
-set_tests_properties(ssdv_receiver PROPERTIES ENVIRONMENT_MODIFICATION
-    "PATH=path_list_prepend:$<TARGET_FILE_DIR:Qt5::Core>;QT_PLUGIN_PATH=set:$<TARGET_FILE_DIR:Qt5::Core>/../plugins")
+
+if(BUILD_TESTING)
+    add_executable(ASRTU1_FrameMonitorTest
+        tests/frame_monitor_test.cpp
+        libs/demod/frame_monitor.cpp
+        libs/demod/frame_monitor.h)
+    target_include_directories(ASRTU1_FrameMonitorTest PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/libs/demod)
+    target_link_libraries(ASRTU1_FrameMonitorTest PRIVATE
+        gnuradio::gnuradio-runtime
+        gnuradio::gnuradio-blocks)
+
+    add_executable(ASRTU1_SsdvTest
+        tests/ssdv_receiver_test.cpp
+        libs/demod/ssdv_receiver.cpp
+        libs/demod/ssdv_receiver.h)
+    target_include_directories(ASRTU1_SsdvTest PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/libs/demod)
+    target_link_libraries(ASRTU1_SsdvTest PRIVATE
+        Qt5::Core Qt5::Gui ssdv_dslwp)
+    target_compile_definitions(ASRTU1_SsdvTest PRIVATE
+        ASRTU_TEST_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/asrtu1_ssdv_capture.b64")
+    if(MSVC)
+        target_compile_options(ASRTU1_FrameMonitorTest PRIVATE
+            /W4 /permissive- /utf-8)
+        target_compile_options(ASRTU1_SsdvTest PRIVATE
+            /W4 /permissive- /utf-8)
+    endif()
+    add_test(NAME frame_monitor COMMAND ASRTU1_FrameMonitorTest)
+    add_test(NAME ssdv_receiver COMMAND ASRTU1_SsdvTest)
+    set_tests_properties(ssdv_receiver PROPERTIES ENVIRONMENT_MODIFICATION
+        "PATH=path_list_prepend:$<TARGET_FILE_DIR:Qt5::Core>;QT_PLUGIN_PATH=set:$<TARGET_FILE_DIR:Qt5::Core>/../plugins")
 endif()

--- a/apps/dsp/main_window.cpp
+++ b/apps/dsp/main_window.cpp
@@ -651,6 +651,7 @@ std::unique_ptr<AsrtuFlowgraph> MainWindow::createFlowgraph(
     options.shared_iq_bridge = shared_iq_bridge_;
     options.fast_playback = fast_playback_;
     options.replay_rate = requestedReplayRate();
+    options.enable_network = playback_path_.isEmpty();
     options.audio_device_id = deviceId;
     options.payload_callback = [this](const std::vector<std::uint8_t>& payload) {
         const QByteArray frame(reinterpret_cast<const char*>(payload.data()),

--- a/libs/demod/frame_monitor.cpp
+++ b/libs/demod/frame_monitor.cpp
@@ -130,19 +130,18 @@ void FrameMonitor::candidateWorker()
     }
 }
 
-std::uint32_t FrameMonitor::candidateKey(
+std::uint64_t FrameMonitor::candidateKey(
     const std::vector<std::uint8_t>& payload)
 {
     if (payload.size() >= 8) {
-        // CCSDS short header is 5 bytes; a DSLWP SSDV packet then starts with
-        // image_id and a 16-bit packet_id. This identity remains stable when
-        // replay runs faster than the 50 ms arbitration window.
-        return (std::uint32_t(payload[5]) << 16) |
-               (std::uint32_t(payload[6]) << 8) | payload[7];
+        std::uint64_t key = 0;
+        for (std::size_t i = 0; i < 8; ++i)
+            key = (key << 8) | payload[i];
+        return key;
     }
-    std::uint32_t key = 2166136261u;
+    std::uint64_t key = 14695981039346656037ULL;
     for (const auto byte : payload)
-        key = (key ^ byte) * 16777619u;
+        key = (key ^ byte) * 1099511628211ULL;
     return key;
 }
 

--- a/libs/demod/frame_monitor.h
+++ b/libs/demod/frame_monitor.h
@@ -49,7 +49,7 @@ private:
     void handleLocalCandidate(const pmt::pmt_t& message,
                               CandidatePriority priority);
     void candidateWorker();
-    static std::uint32_t candidateKey(const std::vector<std::uint8_t>& payload);
+    static std::uint64_t candidateKey(const std::vector<std::uint8_t>& payload);
     static std::string describePdu(const pmt::pmt_t& message);
 
     Callback callback_;
@@ -78,7 +78,7 @@ private:
     };
     std::mutex candidate_mutex_;
     std::condition_variable candidate_cv_;
-    std::map<std::uint32_t, PendingCandidate> pending_candidates_;
+    std::map<std::uint64_t, PendingCandidate> pending_candidates_;
     bool stop_candidate_worker_ = false;
     std::thread candidate_worker_;
 };

--- a/libs/demod/ssdv_receiver.cpp
+++ b/libs/demod/ssdv_receiver.cpp
@@ -137,7 +137,15 @@ bool SsdvReceiver::processFrame(const QByteArray& frame)
 
     ssdv_packet_info_t info{};
     ssdv_dec_header(&info, bytes, ssdv_dslwp_mode);
-    if (image_id_ != int(info.image_id)) {
+    const std::uint16_t packetId = info.packet_id;
+    const auto firstPacket = packets_.find(0);
+    const bool replacedFirstPacket =
+        packetId == 0 && firstPacket != packets_.end() &&
+        firstPacket->second != packet;
+    if (image_id_ != int(info.image_id) ||
+        spacecraft_header_ != spacecraftHeader || width_ != info.width ||
+        height_ != info.height || quality_ != info.quality ||
+        replacedFirstPacket) {
         packets_.clear();
         image_id_ = info.image_id;
         width_ = info.width;
@@ -149,14 +157,13 @@ bool SsdvReceiver::processFrame(const QByteArray& frame)
         image_path_ = QDir(session_directory_).filePath(
             QStringLiteral("SSDV_%1_ID%2.jpg")
                 .arg(QDateTime::currentDateTime().toString(
-                    QStringLiteral("yyyyMMdd_HHmmss")))
+                    QStringLiteral("yyyyMMdd_HHmmss_zzz")))
                 .arg(image_id_));
         if (log_callback_)
             log_callback_(QStringLiteral("SSDV image started: ID %1, %2x%3, quality %4")
                               .arg(image_id_).arg(width_).arg(height_).arg(quality_));
     }
 
-    const std::uint16_t packetId = info.packet_id;
     const auto existing = packets_.find(packetId);
     if (existing != packets_.end() && existing->second == packet)
         return false;

--- a/tests/frame_monitor_test.cpp
+++ b/tests/frame_monitor_test.cpp
@@ -1,0 +1,76 @@
+#include "frame_monitor.h"
+
+#include <gnuradio/blocks/message_debug.h>
+#include <gnuradio/top_block.h>
+#include <pmt/pmt.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+int main()
+{
+	std::atomic<int> candidates{0};
+	const auto monitor = FrameMonitor::make({}, {}, [&](const auto &) {
+		candidates.fetch_add(1, std::memory_order_relaxed);
+	});
+	const auto local = gr::blocks::message_debug::make();
+	const auto graph = gr::make_top_block("frame-monitor-test");
+	std::vector<std::uint8_t> payload(223);
+	std::vector<std::thread> threads;
+
+	graph->msg_connect(monitor, "out", local, "store");
+	graph->start();
+	for (std::size_t i = 0; i < payload.size(); ++i)
+		payload[i] = std::uint8_t(i);
+	const auto message =
+	    pmt::cons(pmt::make_dict(),
+		      pmt::init_u8vector(payload.size(), payload.data()));
+	for (int i = 0; i < 8; ++i) {
+		threads.emplace_back([monitor, message, i] {
+			monitor->_post(
+			    pmt::intern(i & 1 ? "openhoshimi" : "primary"),
+			    message);
+		});
+	}
+	for (auto &thread : threads)
+		thread.join();
+
+	auto second = payload;
+	payload[0] = 0x03;
+	payload[1] = 0x22;
+	second[0] = 0x20;
+	second[1] = 0x52;
+	payload[5] = second[5] = 0x2b;
+	payload[6] = second[6] = 0x00;
+	payload[7] = second[7] = 0x22;
+	monitor->_post(
+	    pmt::intern("local_openhoshimi"),
+	    pmt::cons(pmt::make_dict(),
+		      pmt::init_u8vector(payload.size(), payload.data())));
+	monitor->_post(
+	    pmt::intern("local_original"),
+	    pmt::cons(pmt::make_dict(),
+		      pmt::init_u8vector(second.size(), second.data())));
+	std::this_thread::sleep_for(std::chrono::milliseconds(200));
+	graph->stop();
+	graph->wait();
+
+	bool normalized = false;
+	if (local->num_messages() == 1) {
+		const auto forwarded = local->get_message(0);
+		normalized = pmt::is_pair(forwarded) &&
+			     pmt::is_null(pmt::car(forwarded)) &&
+			     pmt::equal(pmt::cdr(forwarded), pmt::cdr(message));
+	}
+	if (!normalized ||
+	    monitor->suppressedDuplicateCount() != 7 ||
+	    candidates.load() != 2) {
+		std::cerr << "Frame monitor arbitration failed\n";
+		return 1;
+	}
+	return 0;
+}

--- a/tests/ssdv_receiver_test.cpp
+++ b/tests/ssdv_receiver_test.cpp
@@ -54,7 +54,8 @@ int main(int argc, char* argv[])
     {
         std::unique_lock<std::mutex> lock(resultMutex);
         if (!resultReady.wait_for(lock, std::chrono::seconds(3), [&] {
-                return updates > 0 && !last.image.isNull();
+                return updates > 0 && !last.image.isNull() &&
+                       last.received_packets >= 20;
             })) {
             std::cerr << "SSDV reconstruction timed out\n";
             return 5;
@@ -70,6 +71,24 @@ int main(int argc, char* argv[])
         !QFileInfo(result.path).fileName().contains(QStringLiteral("ID43"))) {
         std::cerr << "SSDV reconstruction did not produce the expected image\n";
         return 5;
+    }
+
+    QByteArray second = data;
+    for (int offset = 0; offset < second.size(); offset += 223) {
+        second[offset] = char(0x20);
+        second[offset + 1] = char(0x52);
+    }
+    for (int offset = 0; offset < second.size(); offset += 223)
+        receiver.ingestFrame(second.mid(offset, 223));
+    {
+        std::unique_lock<std::mutex> lock(resultMutex);
+        if (!resultReady.wait_for(lock, std::chrono::seconds(3), [&] {
+                return last.spacecraft_header == 0x2052 &&
+                       last.satellite == QStringLiteral("BY-04");
+            })) {
+            std::cerr << "SSDV session identity did not change\n";
+            return 6;
+        }
     }
     std::cout << "SSDV OK: " << result.path.toLocal8Bit().constData() << '\n';
     return 0;

--- a/third_party/openhoshimi_soundmodem/csrc/smdsp.c
+++ b/third_party/openhoshimi_soundmodem/csrc/smdsp.c
@@ -264,6 +264,10 @@ static void sm_agc(struct sm_demod *d, const struct sm_cf *in,
 		d->agc_buffer[d->agc_index] = in[i];
 		d->agc_index = (d->agc_index + 1) % SM_AGC_WINDOW;
 
+		while (d->agc_dq_head != d->agc_dq_tail &&
+		       d->agc_dq_pos[d->agc_dq_head] + SM_AGC_WINDOW <= t)
+			d->agc_dq_head = (d->agc_dq_head + 1) % cap;
+
 		/* Drop back entries no larger than the incoming envelope. */
 		while (d->agc_dq_head != d->agc_dq_tail) {
 			size_t back = (d->agc_dq_tail + cap - 1) % cap;
@@ -276,11 +280,6 @@ static void sm_agc(struct sm_demod *d, const struct sm_cf *in,
 		d->agc_dq_pos[d->agc_dq_tail] = t;
 		d->agc_dq_env[d->agc_dq_tail] = e;
 		d->agc_dq_tail = (d->agc_dq_tail + 1) % cap;
-
-		/* Drop the front once it leaves the [t-window+1, t] window. */
-		while (d->agc_dq_head != d->agc_dq_tail &&
-		       d->agc_dq_pos[d->agc_dq_head] + SM_AGC_WINDOW <= t)
-			d->agc_dq_head = (d->agc_dq_head + 1) % cap;
 
 		max = d->agc_dq_env[d->agc_dq_head];
 		if (max < 0.0000001f)

--- a/third_party/openhoshimi_soundmodem/vendor/ccsds.c
+++ b/third_party/openhoshimi_soundmodem/vendor/ccsds.c
@@ -26,6 +26,7 @@
 
 #include "ccsds.h"
 #include <stdio.h>
+#include <string.h>
 
 #define TX_EN()
 #define TX_DIS()
@@ -41,7 +42,7 @@ void ccsds_init(Ccsds *cc, uint32_t sync_word, uint16_t len_frame, void *obj_ptr
 
 
     //gen_met(mettab, amp, esn0, 0.0, 4);
-
+    memset(cc, 0, sizeof(*cc));
     vitfilt27_init(&(cc->vi));
 
     cc->sending = 0;
@@ -304,6 +305,7 @@ void ccsds_rx_proc(Ccsds *cc, unsigned char *syms, unsigned int n_syms)
     {
         for (i = 0; i < n_syms/8; i++)
         {
+            current_out = 0;
             for(j=0; j<8; j++)
             {
                 current_out <<= 1;
@@ -351,6 +353,8 @@ void ccsds_pull(Ccsds *cc)
     uint8_t current_in;
     int16_t byte_corr;
 
+    if (fifo_isempty(&cc->rx_fifo))
+        return;
 
     while((!fifo_isempty(&(cc->rx_fifo))) || mask_bit_in)
     {
@@ -457,8 +461,5 @@ void ccsds_pull(Ccsds *cc)
         mask_bit_in >>= 1;
     }
 }
-
-
-
 
 

--- a/third_party/openhoshimi_soundmodem/vendor/viterbi27.c
+++ b/third_party/openhoshimi_soundmodem/vendor/viterbi27.c
@@ -62,7 +62,7 @@
 	vi->nmetric[2*i] = m0;\
 	if(m1 > m0){\
 		vi->nmetric[2*i] = m1;\
-		vi->dec |= 1 << ((2*i) & 31);\
+		vi->dec |= 1UL << ((2*i) & 31);\
 	}\
 	/* ACS for 1 branch */\
 	m0 -= (vi->mets[sym] - vi->mets[3^sym]);\
@@ -70,7 +70,7 @@
 	vi->nmetric[2*i+1] = m0;\
 	if(m1 > m0){\
 		vi->nmetric[2*i+1] = m1;\
-		vi->dec |= 1 << ((2*i+1) & 31);\
+		vi->dec |= 1UL << ((2*i+1) & 31);\
 	}\
 }
 
@@ -82,7 +82,7 @@
 	vi->cmetric[2*i] = m0;\
 	if(m1 > m0){\
 		vi->cmetric[2*i] = m1;\
-		vi->dec |= 1 << ((2*i) & 31);\
+		vi->dec |= 1UL << ((2*i) & 31);\
 	}\
 	/* ACS for 1 branch */\
 	m0 -= (vi->mets[sym] - vi->mets[3^sym]);\
@@ -90,7 +90,7 @@
 	vi->cmetric[2*i+1] = m0;\
 	if(m1 > m0){\
 		vi->cmetric[2*i+1] = m1;\
-		vi->dec |= 1 << ((2*i+1) & 31);\
+		vi->dec |= 1UL << ((2*i+1) & 31);\
 	}\
 }
 
@@ -135,7 +135,7 @@ traceback(unsigned long paths[],unsigned int pi, unsigned char *dst)
     pi = (pi - 1) % PATHMEM;	/* Undo last increment of pi */
     for(i=0; i < MERGEDIST-6; i++)
     {
-        if(paths[2*pi + (beststate >> 5)] & (1 << (beststate & 31)))
+        if(paths[2*pi + (beststate >> 5)] & (1UL << (beststate & 31)))
         {
             beststate |= 64;	/* 2^(K-1) */
         }
@@ -151,7 +151,7 @@ traceback(unsigned long paths[],unsigned int pi, unsigned char *dst)
         data[j] = 0;
         for(i=0; i<8; i++)
         {
-            if(paths[2*pi + (beststate >> 5)] & (1 << (beststate & 31)))
+            if(paths[2*pi + (beststate >> 5)] & (1UL << (beststate & 31)))
             {
                 beststate |= 64;	/* 2^(K-1) */
                 data[j] |= 1 << i;
@@ -324,5 +324,3 @@ void encode27(unsigned char *encstate, unsigned char *symbols, unsigned char *da
 
     return;
 }
-
-

--- a/third_party/ssdv_dslwp/ssdv.c
+++ b/third_party/ssdv_dslwp/ssdv.c
@@ -1352,7 +1352,9 @@ char ssdv_dec_feed(ssdv_t *s, uint8_t *packet, ssdv_mode_t mode)
 			break;
 		default:
 			s->type      = packet[1] - 0x66;
-			s->callsign  = (packet[2] << 24) | (packet[3] << 16) | (packet[4] << 8) | packet[5];
+			s->callsign  = ((uint32_t)packet[2] << 24) |
+				       ((uint32_t)packet[3] << 16) |
+				       ((uint32_t)packet[4] << 8) | packet[5];
 			break;
 		}
 		
@@ -1531,7 +1533,9 @@ char ssdv_dec_is_packet(uint8_t *packet, int *errors, ssdv_mode_t mode)
 			  mode == ssdv_dslwp_mode ? CRC32_DSLWP_MAGIC_VALUE : CRC32_INITIAL_VALUE);
 		
 		i = pkt_offset + pkt_size_crcdata;
-		if(x == (pkt[i + 3] | (pkt[i + 2] << 8) | (pkt[i + 1] << 16) | (pkt[i] << 24)))
+		if(x == (pkt[i + 3] | ((uint32_t)pkt[i + 2] << 8) |
+			 ((uint32_t)pkt[i + 1] << 16) |
+			 ((uint32_t)pkt[i] << 24)))
 		{
 			/* Valid, set the type and continue */
 			type = mode == ssdv_dslwp_mode ? SSDV_TYPE_DSLWP : SSDV_TYPE_NOFEC;
@@ -1550,7 +1554,9 @@ char ssdv_dec_is_packet(uint8_t *packet, int *errors, ssdv_mode_t mode)
 		x = crc32(&pkt[1], pkt_size_crcdata, CRC32_INITIAL_VALUE);
 		
 		i = 1 + pkt_size_crcdata;
-		if(x == (pkt[i + 3] | (pkt[i + 2] << 8) | (pkt[i + 1] << 16) | (pkt[i] << 24)))
+		if(x == (pkt[i + 3] | ((uint32_t)pkt[i + 2] << 8) |
+			 ((uint32_t)pkt[i + 1] << 16) |
+			 ((uint32_t)pkt[i] << 24)))
 		{
 			/* Valid, set the type and continue */
 			type = SSDV_TYPE_NORMAL;
@@ -1574,7 +1580,9 @@ char ssdv_dec_is_packet(uint8_t *packet, int *errors, ssdv_mode_t mode)
 		x = crc32(&pkt[1], pkt_size_crcdata, CRC32_INITIAL_VALUE);
 		
 		i = 1 + pkt_size_crcdata;
-		if(x == (pkt[i + 3] | (pkt[i + 2] << 8) | (pkt[i + 1] << 16) | (pkt[i] << 24)))
+		if(x == (pkt[i + 3] | ((uint32_t)pkt[i + 2] << 8) |
+			 ((uint32_t)pkt[i + 1] << 16) |
+			 ((uint32_t)pkt[i] << 24)))
 		{
 			/* Valid, set the type and continue */
 			type = SSDV_TYPE_NORMAL;
@@ -1617,7 +1625,9 @@ void ssdv_dec_header(ssdv_packet_info_t *info, uint8_t *packet, ssdv_mode_t mode
 	
 	if(mode == ssdv_normal_mode)
 	{
-		info->callsign   = (packet[2] << 24) | (packet[3] << 16) | (packet[4] << 8) | packet[5];
+		info->callsign   = ((uint32_t)packet[2] << 24) |
+				   ((uint32_t)packet[3] << 16) |
+				   ((uint32_t)packet[4] << 8) | packet[5];
 		decode_callsign(info->callsign_s, info->callsign);
 		/* The rest of the header coincides with a DSLWP packet header */
 		packet += 6;
@@ -1685,4 +1695,3 @@ int ssdv_pkt_size_header(ssdv_mode_t mode) {
 }
 
 /*****************************************************************************/
-


### PR DESCRIPTION
Failed SSDV candidates use only image and packet IDs as their arbitration key.  Different spacecraft can therefore collapse into one candidate when their identifiers overlap.  Recorded playback also leaves TCP and ZMQ transports enabled.

Include the spacecraft header in candidate identity and disable network transports during replay.  Reset SSDV state whenever the source, geometry, quality, or first packet changes.

Correct the OpenHoshimi AGC eviction order.  Initialize CCSDS state and use unsigned shifts for Viterbi decisions and SSDV fields.  Add tests for concurrent first-wins delivery, normalized PDU output, and SSDV session changes.

Fixes: f7b38ac68337 ("upload: restore telemetry frame publication")
Fixes: c7d059e01ca3 ("feat(dsp): add OpenHoshimi parallel decoder")
Fixes: fe0126898086 ("feat(dsp): SSDV image reception; scroll waterfall during fast replay")