### PR TITLE
ssdv: isolate repeated downlinks and harden decoding

### DIFF
--- a/apps/dsp/ssdv_image_window.cpp
+++ b/apps/dsp/ssdv_image_window.cpp
@@ -19,6 +19,7 @@
 #include <utility>
 
 namespace {
+constexpr int kMaxGalleryImages = 32;
 
 QString kTitleStyle = QStringLiteral(
     "font-size:16px; font-weight:700; color:#17202a;");
@@ -299,6 +300,9 @@ void SsdvImageWindow::setClearCallback(std::function<void()> callback)
 
 void SsdvImageWindow::updateImage(const SsdvImageUpdate& update)
 {
+    if (update.generation < minimum_generation_)
+        return;
+
     int index = -1;
     for (int i = 0; i < gallery_.size(); ++i) {
         if (gallery_.at(i).path == update.path) {
@@ -311,6 +315,12 @@ void SsdvImageWindow::updateImage(const SsdvImageUpdate& update)
         index = gallery_.size() - 1;
     } else {
         gallery_[index] = update;
+    }
+    if (gallery_.size() > kMaxGalleryImages) {
+        gallery_.removeFirst();
+        --index;
+        if (gallery_index_ > 0)
+            --gallery_index_;
     }
     // Follow the newest image while it is arriving. If the operator is
     // browsing an older image, keep that selection stable.
@@ -395,6 +405,7 @@ void SsdvImageWindow::refreshMetadata()
 
 void SsdvImageWindow::clearDisplay()
 {
+    ++minimum_generation_;
     image_ = {};
     image_path_.clear();
     gallery_.clear();
@@ -436,4 +447,3 @@ void SsdvImageWindow::refreshPixmap()
     image_label_->setPixmap(QPixmap::fromImage(image_).scaled(
         target, Qt::KeepAspectRatio, Qt::SmoothTransformation));
 }
-

--- a/apps/dsp/ssdv_image_window.h
+++ b/apps/dsp/ssdv_image_window.h
@@ -50,6 +50,7 @@ private:
     QImage image_;
     QString image_path_;
     QVector<SsdvImageUpdate> gallery_;
+    std::uint64_t minimum_generation_ = 0;
     int gallery_index_ = -1;
     std::function<void()> clear_callback_;
 };

--- a/libs/demod/ssdv_receiver.cpp
+++ b/libs/demod/ssdv_receiver.cpp
@@ -9,261 +9,321 @@ extern "C" {
 #include <QSaveFile>
 
 #include <chrono>
+#include <limits>
 #include <vector>
 
 namespace {
 constexpr int kCcsdsFrameSize = 223;
 constexpr int kCcsdsShortHeaderSize = 5;
 constexpr int kDslwpPacketSize = 218;
-constexpr int kImageBufferSize = 4 * 1024 * 1024;
+constexpr std::size_t kImageBufferSize = 32 * 1024 * 1024;
+constexpr std::size_t kMaxQueuedFrames = 4096;
 constexpr auto kPreviewRefreshInterval = std::chrono::milliseconds(100);
 
 int virtualChannelId(const QByteArray& frame)
 {
-    const auto word = (std::uint16_t(std::uint8_t(frame[0])) << 8) |
-                      std::uint8_t(frame[1]);
-    return (word >> 1) & 0x07;
+	const auto word = (std::uint16_t(std::uint8_t(frame[0])) << 8) |
+			  std::uint8_t(frame[1]);
+
+	return (word >> 1) & 0x07;
 }
 
 QString satelliteName(std::uint16_t header)
 {
-    if (header == 0x0322)
-        return QStringLiteral("ASRTU-1");
-    if (header == 0x2052)
-        return QStringLiteral("BY-04");
-    return QStringLiteral("Unknown (header %1)")
-        .arg(header, 4, 16, QLatin1Char('0')).toUpper();
+	if (header == 0x0322)
+		return QStringLiteral("ASRTU-1");
+	if (header == 0x2052)
+		return QStringLiteral("BY-04");
+
+	return QStringLiteral("Unknown (header %1)")
+		.arg(header, 4, 16, QLatin1Char('0')).toUpper();
 }
 }
 
 SsdvReceiver::SsdvReceiver(QString sessionDirectory,
-                           ImageCallback imageCallback,
-                           LogCallback logCallback)
-    : session_directory_(std::move(sessionDirectory)),
-      image_callback_(std::move(imageCallback)),
-      log_callback_(std::move(logCallback))
+			   ImageCallback imageCallback,
+			   LogCallback logCallback)
+	: session_directory_(std::move(sessionDirectory)),
+	  image_callback_(std::move(imageCallback)),
+	  log_callback_(std::move(logCallback))
 {
-    worker_ = std::thread([this] { workerLoop(); });
-}
-
-void SsdvReceiver::ingestFrame(const QByteArray& frame)
-{
-    {
-        std::lock_guard<std::mutex> lock(queue_mutex_);
-        if (stop_requested_)
-            return;
-        frame_queue_.push_back(frame);
-    }
-    queue_cv_.notify_one();
+	worker_ = std::thread([this] { workerLoop(); });
 }
 
 SsdvReceiver::~SsdvReceiver()
 {
-    {
-        std::lock_guard<std::mutex> lock(queue_mutex_);
-        stop_requested_ = true;
-        frame_queue_.clear();
-    }
-    queue_cv_.notify_all();
-    if (worker_.joinable())
-        worker_.join();
+	{
+		std::lock_guard<std::mutex> lock(queue_mutex_);
+		stop_requested_ = true;
+		frame_queue_.clear();
+	}
+	queue_cv_.notify_all();
+	if (worker_.joinable())
+		worker_.join();
 }
 
-void SsdvReceiver::workerLoop()
+void SsdvReceiver::ingestFrame(const QByteArray& frame)
 {
-    bool dirty = false;
-    auto nextRefresh = std::chrono::steady_clock::now();
-    while (true) {
-        std::deque<QByteArray> batch;
-        bool clearNow = false;
-        {
-            std::unique_lock<std::mutex> lock(queue_mutex_);
-            if (!dirty) {
-                queue_cv_.wait(lock, [this] {
-                    return stop_requested_ || clear_requested_ ||
-                           !frame_queue_.empty();
-                });
-            } else {
-                queue_cv_.wait_until(lock, nextRefresh, [this] {
-                    return stop_requested_ || clear_requested_ ||
-                           !frame_queue_.empty();
-                });
-            }
-            if (stop_requested_)
-                break;
-            clearNow = clear_requested_;
-            clear_requested_ = false;
-            batch.swap(frame_queue_);
-        }
-
-        if (clearNow) {
-            clearState();
-            dirty = false;
-            nextRefresh = std::chrono::steady_clock::now();
-        }
-        bool urgent = false;
-        for (const auto& frame : batch) {
-            if (processFrame(frame)) {
-                dirty = true;
-                urgent = urgent || complete_;
-            }
-        }
-        const auto now = std::chrono::steady_clock::now();
-        if (dirty && (urgent || now >= nextRefresh)) {
-            rebuildImage();
-            dirty = false;
-            nextRefresh = std::chrono::steady_clock::now() +
-                          kPreviewRefreshInterval;
-        }
-    }
-}
-
-bool SsdvReceiver::processFrame(const QByteArray& frame)
-{
-    if (frame.size() != kCcsdsFrameSize || virtualChannelId(frame) != 1)
-        return false;
-
-    const auto spacecraftHeader =
-        (std::uint16_t(std::uint8_t(frame[0])) << 8) | std::uint8_t(frame[1]);
-
-    QByteArray packet = frame.mid(kCcsdsShortHeaderSize, kDslwpPacketSize);
-    if (packet.size() != kDslwpPacketSize)
-        return false;
-
-    int errors = 0;
-    auto* bytes = reinterpret_cast<std::uint8_t*>(packet.data());
-    if (ssdv_dec_is_packet(bytes, &errors, ssdv_dslwp_mode) != 0)
-        return false;
-
-    ssdv_packet_info_t info{};
-    ssdv_dec_header(&info, bytes, ssdv_dslwp_mode);
-    const std::uint16_t packetId = info.packet_id;
-    const auto firstPacket = packets_.find(0);
-    const bool replacedFirstPacket =
-        packetId == 0 && firstPacket != packets_.end() &&
-        firstPacket->second != packet;
-    if (image_id_ != int(info.image_id) ||
-        spacecraft_header_ != spacecraftHeader || width_ != info.width ||
-        height_ != info.height || quality_ != info.quality ||
-        replacedFirstPacket) {
-        packets_.clear();
-        image_id_ = info.image_id;
-        width_ = info.width;
-        height_ = info.height;
-        quality_ = info.quality;
-        complete_ = false;
-        spacecraft_header_ = spacecraftHeader;
-        satellite_ = satelliteName(spacecraft_header_);
-        image_path_ = QDir(session_directory_).filePath(
-            QStringLiteral("SSDV_%1_ID%2.jpg")
-                .arg(QDateTime::currentDateTime().toString(
-                    QStringLiteral("yyyyMMdd_HHmmss_zzz")))
-                .arg(image_id_));
-        if (log_callback_)
-            log_callback_(QStringLiteral("SSDV image started: ID %1, %2x%3, quality %4")
-                              .arg(image_id_).arg(width_).arg(height_).arg(quality_));
-    }
-
-    const auto existing = packets_.find(packetId);
-    if (existing != packets_.end() && existing->second == packet)
-        return false;
-    packets_[packetId] = packet;
-    complete_ = complete_ || info.eoi != 0;
-    return true;
-}
-
-bool SsdvReceiver::rebuildImage()
-{
-    if (packets_.empty())
-        return false;
-
-    ssdv_t decoder{};
-    if (ssdv_dec_init(&decoder) != SSDV_OK)
-        return false;
-    std::vector<std::uint8_t> jpegBuffer(kImageBufferSize);
-    if (ssdv_dec_set_buffer(&decoder, jpegBuffer.data(), jpegBuffer.size()) != SSDV_OK)
-        return false;
-
-    for (auto& entry : packets_) {
-        auto* packet = reinterpret_cast<std::uint8_t*>(entry.second.data());
-        // Starting mid-image is a normal weak-signal case. The reference
-        // decoder reports the leading gap but still fills the missing MCUs
-        // and can produce the best available partial JPEG.
-        ssdv_dec_feed(&decoder, packet, ssdv_dslwp_mode);
-    }
-
-    std::uint8_t* jpeg = nullptr;
-    std::size_t jpegLength = 0;
-    if (ssdv_dec_get_jpeg(&decoder, &jpeg, &jpegLength) != SSDV_OK ||
-        jpeg == nullptr || jpegLength == 0)
-        return false;
-
-    const QByteArray encoded(reinterpret_cast<const char*>(jpeg), int(jpegLength));
-    const QImage image = QImage::fromData(encoded, "JPEG");
-    if (image.isNull())
-        return false;
-
-    QSaveFile output(image_path_);
-    if (!output.open(QIODevice::WriteOnly) || output.write(encoded) != encoded.size() ||
-        !output.commit()) {
-        if (log_callback_)
-            log_callback_(QStringLiteral("Unable to save SSDV image: %1")
-                              .arg(image_path_));
-        return false;
-    }
-
-    const int first = packets_.begin()->first;
-    const int last = packets_.rbegin()->first;
-    std::vector<std::uint16_t> missingIds;
-    // SSDV packet numbering starts at zero. If reception begins in the middle
-    // of an image, the unseen leading packet IDs are confirmed losses too.
-    for (int id = 0; id <= last; ++id) {
-        if (packets_.find(std::uint16_t(id)) == packets_.end())
-            missingIds.push_back(std::uint16_t(id));
-    }
-
-    SsdvImageUpdate update;
-    update.image = image;
-    update.path = image_path_;
-    update.satellite = satellite_;
-    update.spacecraft_header = spacecraft_header_;
-    update.image_id = image_id_;
-    update.width = width_;
-    update.height = height_;
-    update.quality = quality_;
-    update.received_packets = int(packets_.size());
-    update.first_packet = first;
-    update.last_packet = last;
-    update.missing_packets = int(missingIds.size());
-    update.received_packet_ids.reserve(packets_.size());
-    for (const auto& entry : packets_)
-        update.received_packet_ids.push_back(entry.first);
-    update.missing_packet_ids = std::move(missingIds);
-    update.complete = complete_;
-    if (image_callback_)
-        image_callback_(update);
-    return true;
+	{
+		std::lock_guard<std::mutex> lock(queue_mutex_);
+		if (stop_requested_)
+			return;
+		if (frame_queue_.size() == kMaxQueuedFrames) {
+			frame_queue_.pop_front();
+			++dropped_frames_;
+		}
+		frame_queue_.push_back({ frame, queue_generation_ });
+	}
+	queue_cv_.notify_one();
 }
 
 void SsdvReceiver::clear()
 {
-    {
-        std::lock_guard<std::mutex> lock(queue_mutex_);
-        frame_queue_.clear();
-        clear_requested_ = true;
-    }
-    queue_cv_.notify_one();
+	{
+		std::lock_guard<std::mutex> lock(queue_mutex_);
+		frame_queue_.clear();
+		++queue_generation_;
+		clear_requested_ = true;
+	}
+	queue_cv_.notify_one();
 }
 
-void SsdvReceiver::clearState()
+bool SsdvReceiver::isCurrentGeneration(std::uint64_t generation)
 {
-    packets_.clear();
-    image_path_.clear();
-    image_id_ = -1;
-    satellite_.clear();
-    spacecraft_header_ = 0;
-    width_ = 0;
-    height_ = 0;
-    quality_ = 0;
-    complete_ = false;
+	std::lock_guard<std::mutex> lock(queue_mutex_);
+
+	return !stop_requested_ && queue_generation_ == generation;
+}
+
+void SsdvReceiver::workerLoop()
+{
+	bool dirty = false;
+	auto nextRefresh = std::chrono::steady_clock::now();
+
+	while (true) {
+		std::deque<QueuedFrame> batch;
+		std::uint64_t generation;
+		std::size_t droppedFrames;
+		bool clearNow;
+
+		{
+			std::unique_lock<std::mutex> lock(queue_mutex_);
+			if (!dirty) {
+				queue_cv_.wait(lock, [this] {
+					return stop_requested_ || clear_requested_ ||
+					       !frame_queue_.empty();
+				});
+			} else {
+				queue_cv_.wait_until(lock, nextRefresh, [this] {
+					return stop_requested_ || clear_requested_ ||
+					       !frame_queue_.empty();
+				});
+			}
+			if (stop_requested_)
+				break;
+			clearNow = clear_requested_;
+			clear_requested_ = false;
+			generation = queue_generation_;
+			droppedFrames = dropped_frames_;
+			dropped_frames_ = 0;
+			batch.swap(frame_queue_);
+		}
+
+		if (clearNow) {
+			clearState(generation);
+			dirty = false;
+			nextRefresh = std::chrono::steady_clock::now();
+		}
+		if (droppedFrames != 0 && log_callback_) {
+			log_callback_(QStringLiteral("SSDV input queue dropped %1 frames")
+					  .arg(droppedFrames));
+		}
+
+		bool urgent = false;
+		for (const auto& queued : batch) {
+			if (!isCurrentGeneration(queued.generation))
+				continue;
+			if (processFrame(queued.frame, queued.generation)) {
+				dirty = true;
+				urgent = urgent || complete_;
+			}
+		}
+
+		const auto now = std::chrono::steady_clock::now();
+		if (dirty && (urgent || now >= nextRefresh)) {
+			rebuildImage();
+			dirty = false;
+			nextRefresh = std::chrono::steady_clock::now() +
+				      kPreviewRefreshInterval;
+		}
+	}
+}
+
+bool SsdvReceiver::processFrame(const QByteArray& frame,
+				std::uint64_t generation)
+{
+	if (frame.size() != kCcsdsFrameSize || virtualChannelId(frame) != 1)
+		return false;
+
+	const auto spacecraftHeader =
+		(std::uint16_t(std::uint8_t(frame[0])) << 8) |
+		std::uint8_t(frame[1]);
+	QByteArray packet = frame.mid(kCcsdsShortHeaderSize, kDslwpPacketSize);
+	int errors = 0;
+
+	if (packet.size() != kDslwpPacketSize)
+		return false;
+
+	auto* bytes = reinterpret_cast<std::uint8_t*>(packet.data());
+	if (ssdv_dec_is_packet(bytes, &errors, ssdv_dslwp_mode) != SSDV_OK)
+		return false;
+
+	ssdv_packet_info_t info{};
+	ssdv_dec_header(&info, bytes, ssdv_dslwp_mode);
+
+	const auto existing = packets_.find(info.packet_id);
+	const auto firstPacket = packets_.find(0);
+	const bool replacedFirstPacket =
+		info.packet_id == 0 && firstPacket != packets_.end() &&
+		firstPacket->second != packet;
+	const bool duplicatePacket =
+		existing != packets_.end() && existing->second == packet;
+	const bool restartCompletedSession = complete_ &&
+		existing == packets_.end();
+	const bool sessionChanged = image_id_ != int(info.image_id) ||
+		spacecraft_header_ != spacecraftHeader || width_ != info.width ||
+		height_ != info.height || quality_ != info.quality ||
+		replacedFirstPacket || restartCompletedSession;
+
+	if (sessionChanged) {
+		packets_.clear();
+		image_id_ = info.image_id;
+		width_ = info.width;
+		height_ = info.height;
+		quality_ = info.quality;
+		complete_ = false;
+		spacecraft_header_ = spacecraftHeader;
+		satellite_ = satelliteName(spacecraft_header_);
+		state_generation_ = generation;
+		image_path_ = QDir(session_directory_).filePath(
+			QStringLiteral("SSDV_%1_Pass%2_ID%3.jpg")
+				.arg(QDateTime::currentDateTime().toString(
+					QStringLiteral("yyyyMMdd_HHmmss_zzz")))
+				.arg(++session_serial_)
+				.arg(image_id_));
+		if (log_callback_) {
+			log_callback_(QStringLiteral("SSDV image started: ID %1, %2x%3, quality %4")
+					  .arg(image_id_).arg(width_).arg(height_).arg(quality_));
+		}
+	}
+
+	if (duplicatePacket && !sessionChanged)
+		return false;
+
+	packets_[info.packet_id] = packet;
+	complete_ = complete_ || info.eoi != 0;
+
+	return true;
+}
+
+bool SsdvReceiver::rebuildImage()
+{
+	if (packets_.empty() || !isCurrentGeneration(state_generation_))
+		return false;
+
+	ssdv_t decoder{};
+	if (ssdv_dec_init(&decoder) != SSDV_OK)
+		return false;
+
+	std::vector<std::uint8_t> jpegBuffer(kImageBufferSize);
+	if (ssdv_dec_set_buffer(&decoder, jpegBuffer.data(), jpegBuffer.size()) !=
+	    SSDV_OK)
+		return false;
+
+	for (const auto& entry : packets_) {
+		const auto* packet = reinterpret_cast<const std::uint8_t*>(
+			entry.second.data());
+		const char result = ssdv_dec_feed(&decoder, packet, ssdv_dslwp_mode);
+
+		if (result != SSDV_FEED_ME && result != SSDV_OK) {
+			if (log_callback_) {
+				log_callback_(QStringLiteral("SSDV decoder rejected packet %1")
+						  .arg(entry.first));
+			}
+			return false;
+		}
+	}
+
+	std::uint8_t* jpeg = nullptr;
+	std::size_t jpegLength = 0;
+	if (ssdv_dec_get_jpeg(&decoder, &jpeg, &jpegLength) != SSDV_OK ||
+	    jpeg == nullptr || jpegLength == 0 ||
+	    jpegLength > std::size_t(std::numeric_limits<int>::max()))
+		return false;
+
+	const QByteArray encoded(reinterpret_cast<const char*>(jpeg),
+				 int(jpegLength));
+	const QImage image = QImage::fromData(encoded, "JPEG");
+	if (image.isNull() || !isCurrentGeneration(state_generation_))
+		return false;
+
+	QSaveFile output(image_path_);
+	if (!output.open(QIODevice::WriteOnly) ||
+	    output.write(encoded) != encoded.size() || !output.commit()) {
+		if (log_callback_) {
+			log_callback_(QStringLiteral("Unable to save SSDV image: %1")
+					  .arg(image_path_));
+		}
+		return false;
+	}
+
+	if (!isCurrentGeneration(state_generation_))
+		return false;
+
+	const int first = packets_.begin()->first;
+	const int last = packets_.rbegin()->first;
+	std::vector<std::uint16_t> missingIds;
+
+	for (int id = 0; id <= last; ++id) {
+		if (packets_.find(std::uint16_t(id)) == packets_.end())
+			missingIds.push_back(std::uint16_t(id));
+	}
+
+	SsdvImageUpdate update;
+	update.image = image;
+	update.path = image_path_;
+	update.satellite = satellite_;
+	update.generation = state_generation_;
+	update.spacecraft_header = spacecraft_header_;
+	update.image_id = image_id_;
+	update.width = width_;
+	update.height = height_;
+	update.quality = quality_;
+	update.received_packets = int(packets_.size());
+	update.first_packet = first;
+	update.last_packet = last;
+	update.missing_packets = int(missingIds.size());
+	update.received_packet_ids.reserve(packets_.size());
+	for (const auto& entry : packets_)
+		update.received_packet_ids.push_back(entry.first);
+	update.missing_packet_ids = std::move(missingIds);
+	update.complete = complete_;
+	if (image_callback_)
+		image_callback_(update);
+
+	return true;
+}
+
+void SsdvReceiver::clearState(std::uint64_t generation)
+{
+	packets_.clear();
+	image_path_.clear();
+	image_id_ = -1;
+	satellite_.clear();
+	spacecraft_header_ = 0;
+	width_ = 0;
+	height_ = 0;
+	quality_ = 0;
+	state_generation_ = generation;
+	complete_ = false;
 }

--- a/libs/demod/ssdv_receiver.h
+++ b/libs/demod/ssdv_receiver.h
@@ -4,6 +4,7 @@
 #include <QImage>
 #include <QString>
 
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <map>
@@ -14,66 +15,71 @@
 #include <vector>
 
 struct SsdvImageUpdate {
-    QImage image;
-    QString path;
-    QString satellite;
-    std::uint16_t spacecraft_header = 0;
-    int image_id = -1;
-    int width = 0;
-    int height = 0;
-    int quality = 0;
-    int received_packets = 0;
-    int first_packet = -1;
-    int last_packet = -1;
-    int missing_packets = 0;
-    // Exact packet IDs received for this image. The UI renders packet
-    // reception rather than inferred MCU coverage: before EOI the final
-    // packet count is unknown, so only holes in the observed sequence are
-    // genuine losses.
-    std::vector<std::uint16_t> received_packet_ids;
-    // Packet IDs in [first_packet, last_packet] that have not been received;
-    // lets the UI render confirmed gaps without guessing from JPEG MCU spans.
-    std::vector<std::uint16_t> missing_packet_ids;
-    bool complete = false;
+	QImage image;
+	QString path;
+	QString satellite;
+	std::uint64_t generation = 0;
+	std::uint16_t spacecraft_header = 0;
+	int image_id = -1;
+	int width = 0;
+	int height = 0;
+	int quality = 0;
+	int received_packets = 0;
+	int first_packet = -1;
+	int last_packet = -1;
+	int missing_packets = 0;
+	std::vector<std::uint16_t> received_packet_ids;
+	std::vector<std::uint16_t> missing_packet_ids;
+	bool complete = false;
 };
 
 class SsdvReceiver final
 {
 public:
-    using ImageCallback = std::function<void(const SsdvImageUpdate&)>;
-    using LogCallback = std::function<void(const QString&)>;
+	using ImageCallback = std::function<void(const SsdvImageUpdate&)>;
+	using LogCallback = std::function<void(const QString&)>;
 
-    SsdvReceiver(QString sessionDirectory,
-                 ImageCallback imageCallback,
-                 LogCallback logCallback = {});
-    ~SsdvReceiver();
+	SsdvReceiver(QString sessionDirectory,
+		     ImageCallback imageCallback,
+		     LogCallback logCallback = {});
+	~SsdvReceiver();
 
-    void ingestFrame(const QByteArray& frame);
-    void clear();
+	void ingestFrame(const QByteArray& frame);
+	void clear();
 
 private:
-    void workerLoop();
-    bool processFrame(const QByteArray& frame);
-    bool rebuildImage();
-    void clearState();
+	struct QueuedFrame {
+		QByteArray frame;
+		std::uint64_t generation;
+	};
 
-    QString session_directory_;
-    QString image_path_;
-    QString satellite_;
-    std::uint16_t spacecraft_header_ = 0;
-    ImageCallback image_callback_;
-    LogCallback log_callback_;
-    std::map<std::uint16_t, QByteArray> packets_;
-    int image_id_ = -1;
-    int width_ = 0;
-    int height_ = 0;
-    int quality_ = 0;
-    bool complete_ = false;
+	void workerLoop();
+	bool processFrame(const QByteArray& frame, std::uint64_t generation);
+	bool rebuildImage();
+	void clearState(std::uint64_t generation);
+	bool isCurrentGeneration(std::uint64_t generation);
 
-    std::mutex queue_mutex_;
-    std::condition_variable queue_cv_;
-    std::deque<QByteArray> frame_queue_;
-    bool clear_requested_ = false;
-    bool stop_requested_ = false;
-    std::thread worker_;
+	QString session_directory_;
+	QString image_path_;
+	QString satellite_;
+	std::uint16_t spacecraft_header_ = 0;
+	ImageCallback image_callback_;
+	LogCallback log_callback_;
+	std::map<std::uint16_t, QByteArray> packets_;
+	int image_id_ = -1;
+	int width_ = 0;
+	int height_ = 0;
+	int quality_ = 0;
+	std::uint64_t state_generation_ = 0;
+	std::uint64_t session_serial_ = 0;
+	bool complete_ = false;
+
+	std::mutex queue_mutex_;
+	std::condition_variable queue_cv_;
+	std::deque<QueuedFrame> frame_queue_;
+	std::uint64_t queue_generation_ = 0;
+	std::size_t dropped_frames_ = 0;
+	bool clear_requested_ = false;
+	bool stop_requested_ = false;
+	std::thread worker_;
 };

--- a/tests/ssdv_receiver_test.cpp
+++ b/tests/ssdv_receiver_test.cpp
@@ -10,6 +10,7 @@
 #include <condition_variable>
 #include <iostream>
 #include <mutex>
+#include <thread>
 
 int main(int argc, char* argv[])
 {
@@ -67,10 +68,50 @@ int main(int argc, char* argv[])
         result.satellite != QStringLiteral("ASRTU-1") ||
         result.spacecraft_header != 0x0322 || result.width != 320 ||
         result.height != 240 || result.received_packets < 20 ||
+        !result.complete ||
         !QFileInfo::exists(result.path) ||
         !QFileInfo(result.path).fileName().contains(QStringLiteral("ID43"))) {
         std::cerr << "SSDV reconstruction did not produce the expected image\n";
         return 5;
+    }
+
+    int updatesBeforeRepeat;
+    {
+        std::lock_guard<std::mutex> lock(resultMutex);
+        updatesBeforeRepeat = updates;
+    }
+    for (int repeat = 0; repeat < 8; ++repeat) {
+        for (int offset = 0; offset < data.size(); offset += 223)
+            receiver.ingestFrame(data.mid(offset, 223));
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+    {
+        std::lock_guard<std::mutex> lock(resultMutex);
+        if (updates != updatesBeforeRepeat ||
+            last.received_packets != result.received_packets ||
+            last.path != result.path) {
+            std::cerr << "SSDV repeated pass changed a completed image\n";
+            return 6;
+        }
+    }
+
+    for (int repeat = 0; repeat < 64; ++repeat) {
+        for (int offset = 0; offset < data.size(); offset += 223)
+            receiver.ingestFrame(data.mid(offset, 223));
+    }
+    receiver.clear();
+    for (int offset = 0; offset < data.size(); offset += 223)
+        receiver.ingestFrame(data.mid(offset, 223));
+    {
+        std::unique_lock<std::mutex> lock(resultMutex);
+        if (!resultReady.wait_for(lock, std::chrono::seconds(3), [&] {
+                return last.generation == 1 && !last.image.isNull() &&
+                       last.received_packets == result.received_packets &&
+                       last.path != result.path;
+            })) {
+            std::cerr << "SSDV clear did not discard the previous session\n";
+            return 7;
+        }
     }
 
     QByteArray second = data;
@@ -87,7 +128,7 @@ int main(int argc, char* argv[])
                        last.satellite == QStringLiteral("BY-04");
             })) {
             std::cerr << "SSDV session identity did not change\n";
-            return 6;
+            return 8;
         }
     }
     std::cout << "SSDV OK: " << result.path.toLocal8Bit().constData() << '\n';

--- a/third_party/ssdv_dslwp/ssdv.c
+++ b/third_party/ssdv_dslwp/ssdv.c
@@ -1221,7 +1221,7 @@ static void ssdv_out_headers(ssdv_t *s)
 	ssdv_write_marker(s, J_SOS,   10, sos);
 }
 
-static void ssdv_fill_gap(ssdv_t *s, uint16_t next_mcu)
+static void ssdv_fill_gap(ssdv_t *s, uint32_t next_mcu)
 {
 	if(s->mcupart > 0 || s->acpart > 0)
 	{
@@ -1283,19 +1283,29 @@ char ssdv_dec_init(ssdv_t *s)
 
 char ssdv_dec_set_buffer(ssdv_t *s, uint8_t *buffer, size_t length)
 {
-	size_t c = s->outp - s->out;
-	
-	s->outp = buffer + c;
+	size_t c = 0;
+
+	if (buffer == NULL)
+		return(SSDV_ERROR);
+
+	if (s->out != NULL || s->outp != NULL)
+	{
+		if (s->out == NULL || s->outp == NULL || s->outp < s->out)
+			return(SSDV_ERROR);
+		c = (size_t) (s->outp - s->out);
+	}
+
+	if (c > length)
+		return(SSDV_BUFFER_FULL);
+
 	s->out = buffer;
+	s->outp = buffer + c;
 	s->out_len = length - c;
-	
-	/* Flush the output bits */
-	ssdv_outbits(s, 0, 0);
-	
-	return(SSDV_OK);
+
+	return(ssdv_outbits(s, 0, 0));
 }
 
-char ssdv_dec_feed(ssdv_t *s, uint8_t *packet, ssdv_mode_t mode)
+char ssdv_dec_feed(ssdv_t *s, const uint8_t *packet, ssdv_mode_t mode)
 {
 	int i = 0, r;
 	uint8_t b;
@@ -1339,9 +1349,6 @@ char ssdv_dec_feed(ssdv_t *s, uint8_t *packet, ssdv_mode_t mode)
 	/* If this is the first packet, write the JPEG headers */
 	if(s->packet_id == 0)
 	{
-		const char *factor;
-		char callsign[SSDV_MAX_CALLSIGN + 1];
-		
 		/* Read the fixed headers from the packet */
 		switch (s->type) {
 		case SSDV_TYPE_DSLWP:
@@ -1361,7 +1368,8 @@ char ssdv_dec_feed(ssdv_t *s, uint8_t *packet, ssdv_mode_t mode)
 		s->image_id  = packet[image_id_offset];
 		s->width     = packet[image_id_offset + 3] << 4;
 		s->height    = packet[image_id_offset + 4] << 4;
-		s->mcu_count = packet[image_id_offset + 3] * packet[image_id_offset + 4];
+		s->mcu_count = (uint32_t) packet[image_id_offset + 3] *
+			       packet[image_id_offset + 4];
 		s->quality   = ((packet[image_id_offset + 5] >> 3) & 7) ^ 4;
 		s->mcu_mode  = packet[image_id_offset + 5] & 0x03;
 		
@@ -1376,19 +1384,11 @@ char ssdv_dec_feed(ssdv_t *s, uint8_t *packet, ssdv_mode_t mode)
 		
 		switch(s->mcu_mode & 3)
 		{
-		case 0: factor = "2x2"; s->ycparts = 4; break;
-		case 1: factor = "1x2"; s->ycparts = 2; s->mcu_count *= 2; break;
-		case 2: factor = "2x1"; s->ycparts = 2; s->mcu_count *= 2; break;
-		case 3: factor = "1x1"; s->ycparts = 1; s->mcu_count *= 4; break;
+		case 0: s->ycparts = 4; break;
+		case 1: s->ycparts = 2; s->mcu_count *= 2; break;
+		case 2: s->ycparts = 2; s->mcu_count *= 2; break;
+		case 3: s->ycparts = 1; s->mcu_count *= 4; break;
 		}
-		
-		/* Display information about the image */
-		fprintf(stderr, "Callsign: %s\n", decode_callsign(callsign, s->callsign));
-		fprintf(stderr, "Image ID: %02X\n", s->image_id);
-		fprintf(stderr, "Resolution: %ix%i\n", s->width, s->height);
-		fprintf(stderr, "MCU blocks: %i\n", s->mcu_count);
-		fprintf(stderr, "Sampling factor: %s\n", factor);
-		fprintf(stderr, "Quality level: %d\n", s->quality);
 		
 		/* Output JPEG headers and enable byte stuffing */
 		ssdv_out_headers(s);
@@ -1400,13 +1400,8 @@ char ssdv_dec_feed(ssdv_t *s, uint8_t *packet, ssdv_mode_t mode)
 	{
 		if(packet_id < s->packet_id)
 		{
-			/* The decoder can only accept packets in the correct order */
-			fprintf(stderr, "Packets are not in order. %i > %i\n", s->packet_id - 1, packet_id);
 			return(SSDV_FEED_ME);
 		}
-		
-		/* One or more packets have been lost! */
-		fprintf(stderr, "Gap detected between packets %i and %i\n", s->packet_id - 1, packet_id);
 		
 		/* If this packet has no new MCU, ignore */
 		if(s->packet_mcu_id == 0xFFFF) return(SSDV_FEED_ME);
@@ -1439,7 +1434,6 @@ char ssdv_dec_feed(ssdv_t *s, uint8_t *packet, ssdv_mode_t mode)
 			/* Abandon the packet if the MCU index is not what it should be. */
 			if(s->mcu_id != s->packet_mcu_id)
 			{
-				fprintf(stderr, "Unexpected MCU ID in packet %d.\n", packet_id);
 				return(SSDV_FEED_ME);
 			}
 		}
@@ -1453,10 +1447,8 @@ char ssdv_dec_feed(ssdv_t *s, uint8_t *packet, ssdv_mode_t mode)
 		/* Process the new data until more needed, or an error occurs */
 		while((r = ssdv_process(s)) == SSDV_OK);
 		
-		if(r == SSDV_BUFFER_FULL)
-		{
-			/* Realloc memory */
-		}
+		if (r == SSDV_BUFFER_FULL)
+			return(SSDV_BUFFER_FULL);
 		else if(r == SSDV_EOI)
 		{
 			/* All done! */
@@ -1464,8 +1456,6 @@ char ssdv_dec_feed(ssdv_t *s, uint8_t *packet, ssdv_mode_t mode)
 		}
 		else if(r != SSDV_FEED_ME)
 		{
-			/* An error occured */
-			fprintf(stderr, "ssdv_process() failed: %i\n", r);
 			return(SSDV_ERROR);
 		}
 	}
@@ -1478,13 +1468,14 @@ char ssdv_dec_feed(ssdv_t *s, uint8_t *packet, ssdv_mode_t mode)
 
 char ssdv_dec_get_jpeg(ssdv_t *s, uint8_t **jpeg, size_t *length)
 {
-	/* Is the image complete? */
-	if(s->mcu_id < s->mcu_count) ssdv_fill_gap(s, s->mcu_count);
-	
-	/* Sync, and final EOI header and return */
-	ssdv_outbits_sync(s);
+	if (s->mcu_id < s->mcu_count)
+		ssdv_fill_gap(s, s->mcu_count);
+	if (ssdv_outbits_sync(s) != SSDV_OK)
+		return(SSDV_BUFFER_FULL);
 	s->out_stuff = 0;
 	ssdv_write_marker(s, J_EOI, 0, 0);
+	if (s->out_len == 0)
+		return(SSDV_BUFFER_FULL);
 	
 	*jpeg = s->out;
 	*length = (size_t) (s->outp - s->out);
@@ -1600,7 +1591,9 @@ char ssdv_dec_is_packet(uint8_t *packet, int *errors, ssdv_mode_t mode)
 	
 	if(p.type != type) return(-1);
 	if(p.width == 0 || p.height == 0) return(-1);
-	if(p.mcu_id != 0xFFFF)
+	if (p.mcu_count == 0 || p.mcu_count > UINT16_MAX)
+		return(-1);
+	if (p.mcu_id != 0xFFFF)
 	{
 		if(p.mcu_id >= p.mcu_count) return(-1);
 		if(p.mcu_offset >= pkt_size_payload) return(-1);
@@ -1612,7 +1605,7 @@ char ssdv_dec_is_packet(uint8_t *packet, int *errors, ssdv_mode_t mode)
 	return(0);
 }
 
-void ssdv_dec_header(ssdv_packet_info_t *info, uint8_t *packet, ssdv_mode_t mode)
+void ssdv_dec_header(ssdv_packet_info_t *info, const uint8_t *packet, ssdv_mode_t mode)
 {
 	if(mode == ssdv_normal_mode || mode == ssdv_jy1sat_mode)
 	{
@@ -1659,7 +1652,7 @@ void ssdv_dec_header(ssdv_packet_info_t *info, uint8_t *packet, ssdv_mode_t mode
 	info->mcu_mode   = packet[5] & 0x03;
 	info->mcu_offset = packet[6];
 	info->mcu_id     = (packet[7] << 8) | packet[8];
-	info->mcu_count  = packet[3] * packet[4];
+	info->mcu_count  = (uint32_t) packet[3] * packet[4];
 	if(info->mcu_mode == 1 || info->mcu_mode == 2) info->mcu_count *= 2;
 	else if(info->mcu_mode == 3) info->mcu_count *= 4;
 }

--- a/third_party/ssdv_dslwp/ssdv.h
+++ b/third_party/ssdv_dslwp/ssdv.h
@@ -16,6 +16,7 @@
 /* You should have received a copy of the GNU General Public License     */
 /* along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
+#include <stddef.h>
 #include <stdint.h>
 
 #ifndef INC_SSDV_H
@@ -76,8 +77,8 @@ typedef struct
 	uint8_t  image_id;
 	uint16_t packet_id;
 	uint8_t  mcu_mode;  /* 0 = 2x2, 1 = 2x1, 2 = 1x2, 3 = 1x1           */
-	uint16_t mcu_id;
-	uint16_t mcu_count;
+	uint32_t mcu_id;
+	uint32_t mcu_count;
 	uint8_t  quality;   /* JPEG quality level for encoding, 0-7         */
 	uint16_t packet_mcu_id;
 	uint8_t  packet_mcu_offset;
@@ -157,7 +158,7 @@ typedef struct {
 	uint16_t mcu_mode;
 	uint8_t  mcu_offset;
 	uint16_t mcu_id;
-	uint16_t mcu_count;
+	uint32_t mcu_count;
 } ssdv_packet_info_t;
 
 /* Encoding */
@@ -169,11 +170,11 @@ extern char ssdv_enc_feed(ssdv_t *s, uint8_t *buffer, size_t length);
 /* Decoding */
 extern char ssdv_dec_init(ssdv_t *s);
 extern char ssdv_dec_set_buffer(ssdv_t *s, uint8_t *buffer, size_t length);
-extern char ssdv_dec_feed(ssdv_t *s, uint8_t *packet, ssdv_mode_t mode);
+extern char ssdv_dec_feed(ssdv_t *s, const uint8_t *packet, ssdv_mode_t mode);
 extern char ssdv_dec_get_jpeg(ssdv_t *s, uint8_t **jpeg, size_t *length);
 
 extern char ssdv_dec_is_packet(uint8_t *packet, int *errors, ssdv_mode_t mode);
-extern void ssdv_dec_header(ssdv_packet_info_t *info, uint8_t *packet, ssdv_mode_t mode);
+extern void ssdv_dec_header(ssdv_packet_info_t *info, const uint8_t *packet, ssdv_mode_t mode);
 
 extern int ssdv_pkt_size(ssdv_mode_t mode);
 extern int ssdv_pkt_size_header(ssdv_mode_t mode);
@@ -182,4 +183,3 @@ extern int ssdv_pkt_size_header(ssdv_mode_t mode);
 }
 #endif
 #endif
-


### PR DESCRIPTION
Keep exactly one copy of each SSDV packet in an active image session. This prevents a repeated downlink of the same completed image from feeding duplicate packets into the decoder and corrupting reconstructed blocks.

Once an image has reached EOI, start a new session on any previously unseen packet ID. This allows a following image to start immediately, without waiting for an idle timeout, while exact duplicate packets remain harmless.

Tag queued frames and image updates with a receiver generation. Clearing the display advances the generation, discards queued frames, and prevents an in-flight worker batch from publishing stale state afterwards. Bound the input queue and image gallery to prevent unbounded memory growth.

Harden the bundled SSDV decoder by removing the initial null-pointer subtraction in ssdv_dec_set_buffer(), preserving MCU counts without 16-bit overflow, rejecting unsupported MCU ranges, reporting output buffer exhaustion, and checking packet decode results in the receiver.

Add coverage for repeated complete-image downlinks and clearing while frames are queued.