### PR TITLE
fix(ui): show version in window titles and elide long playback names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,8 @@ else()
 endif()
 
 target_compile_definitions(ASRTU1_Demod_CQt PRIVATE
-    _USE_MATH_DEFINES HYACINTHSAT_GR_310)
+    _USE_MATH_DEFINES HYACINTHSAT_GR_310
+    ASRTU_VERSION="${PROJECT_VERSION}")
 if(WIN32)
     target_compile_definitions(ASRTU1_Demod_CQt PRIVATE
         NOMINMAX WIN32_LEAN_AND_MEAN)
@@ -198,6 +199,7 @@ endif()
 if(MSVC)
     target_compile_options(ASRTU1_Launcher PRIVATE /W4 /permissive- /utf-8)
 endif()
+target_compile_definitions(ASRTU1_Launcher PRIVATE ASRTU_VERSION="${PROJECT_VERSION}")
 asrtu_enable_strict_warnings(ASRTU1_Launcher)
 
 add_executable(ASRTU_Doppler
@@ -229,6 +231,7 @@ endif()
 if(MSVC)
     target_compile_options(ASRTU_Doppler PRIVATE /W4 /permissive- /utf-8)
 endif()
+target_compile_definitions(ASRTU_Doppler PRIVATE ASRTU_VERSION="${PROJECT_VERSION}")
 asrtu_enable_strict_warnings(ASRTU_Doppler)
 
 install(TARGETS ASRTU1_Launcher ASRTU_Doppler

--- a/apps/doppler/satellite_tracker_dialog.cpp
+++ b/apps/doppler/satellite_tracker_dialog.cpp
@@ -1,4 +1,5 @@
 #include "satellite_tracker_dialog.h"
+#include "version.h"
 
 #include <QComboBox>
 #include <QCoreApplication>
@@ -67,7 +68,8 @@ SatelliteTrackerDialog::SatelliteTrackerDialog(
     setWindowFlags(Qt::Window | Qt::WindowTitleHint | Qt::WindowSystemMenuHint |
                    Qt::WindowMinimizeButtonHint | Qt::WindowMaximizeButtonHint |
                    Qt::WindowCloseButtonHint);
-    setWindowTitle(QCoreApplication::translate("ASRTU", "阿斯图系列卫星跟踪与多普勒"));
+    setWindowTitle(QCoreApplication::translate("ASRTU", "阿斯图系列卫星跟踪与多普勒") +
+                   QStringLiteral(" v") + QStringLiteral(ASRTU_VERSION));
     setWindowIcon(QIcon(QStringLiteral(":/icons/win98_doppler.png")));
     setAttribute(Qt::WA_DeleteOnClose, true);
     buildUi();

--- a/apps/dsp/main_window.cpp
+++ b/apps/dsp/main_window.cpp
@@ -6,6 +6,7 @@
 #include "snr_plot.h"
 #include "ssdv_image_window.h"
 #include "ssdv_receiver.h"
+#include "version.h"
 
 #include <QApplication>
 #include <QCloseEvent>
@@ -280,7 +281,8 @@ QString compactSessionPath(const QString& sessionDirectory, const QString& path)
 
 MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent)
 {
-    setWindowTitle(QCoreApplication::translate("ASRTU", "阿斯图系列卫星接收解码"));
+    setWindowTitle(QCoreApplication::translate("ASRTU", "阿斯图系列卫星接收解码") +
+                   QStringLiteral(" v") + QStringLiteral(ASRTU_VERSION));
     setMinimumSize(760, 640);
     if (const QScreen* screen = QGuiApplication::primaryScreen()) {
         const QSize available = screen->availableGeometry().size();

--- a/apps/launcher/suite_launcher.cpp
+++ b/apps/launcher/suite_launcher.cpp
@@ -10,6 +10,7 @@
 #include <QDir>
 #include <QDoubleSpinBox>
 #include <QElapsedTimer>
+#include <QEvent>
 #include <QFile>
 #include <QFileInfo>
 #include <QFileDialog>
@@ -28,6 +29,7 @@
 #include <QProcessEnvironment>
 #include <QPushButton>
 #include <QRegularExpression>
+#include <QResizeEvent>
 #include <QSaveFile>
 #include <QScrollArea>
 #include <QSettings>
@@ -45,6 +47,7 @@
 
 #include "translation.h"
 #include "runtime_paths.h"
+#include "version.h"
 
 #include <algorithm>
 #include <cmath>
@@ -493,7 +496,8 @@ public:
     {
         // Keep the launcher available while decoder/proxy windows are created.
         setWindowIcon(QIcon(QStringLiteral(":/launcher/astro_series_launcher.png")));
-        setWindowTitle(QCoreApplication::translate("ASRTU", "阿斯图系列卫星启动器"));
+        setWindowTitle(QCoreApplication::translate("ASRTU", "阿斯图系列卫星启动器") +
+                       QStringLiteral(" v") + QStringLiteral(ASRTU_VERSION));
         // Keep the launcher compact on low-resolution and high-DPI displays.
         // The scroll area below keeps all controls reachable at the minimum size.
         setMinimumSize(260, 300);
@@ -669,6 +673,11 @@ public:
         status_label_ = new QLabel(QCoreApplication::translate("ASRTU", "就绪"), this);
         status_label_->setStyleSheet(QStringLiteral(
             "color:#667788; padding:0 2px 2px 2px;"));
+        // A long playback filename must not widen the launcher; the label
+        // width is layout-driven and long text is elided in setStatusText().
+        status_label_->setMinimumWidth(0);
+        status_label_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+        status_label_->installEventFilter(this);
         layout->addWidget(status_label_);
 
         auto* buttons = new QGridLayout;
@@ -742,7 +751,7 @@ public:
                 QMessageBox::critical(this, errorTitle, error);
                 return;
             }
-            status_label_->setText(
+            setStatusText(
                 QCoreApplication::translate("ASRTU", "正在播放：/%1；日志：%2")
                     .arg(QFileInfo(wavPath).fileName(),
                          compactSessionDirectory(sessionDirectory)));
@@ -777,7 +786,7 @@ public:
                 QMessageBox::critical(this, QCoreApplication::translate("ASRTU", "上传代理启动失败"), error);
                 return;
             }
-            status_label_->setText(
+            setStatusText(
                 QCoreApplication::translate("ASRTU", "上传代理已启动（PID %1）").arg(processId));
         });
         connect(start, &QPushButton::clicked, this, [this] {
@@ -811,7 +820,7 @@ public:
                 QMessageBox::critical(this, QCoreApplication::translate("ASRTU", "启动失败"), error);
                 return;
             }
-            status_label_->setText(
+            setStatusText(
                 QCoreApplication::translate("ASRTU", "接收已启动；录音与日志：%1")
                     .arg(compactSessionDirectory(sessionDirectory)));
         });
@@ -877,6 +886,40 @@ public:
     }
 
 private:
+    void setStatusText(const QString& text)
+    {
+        status_text_ = text;
+        refreshStatusElide();
+    }
+
+    void refreshStatusElide()
+    {
+        if (!status_label_)
+            return;
+        const int available = status_label_->width();
+        if (available > 0) {
+            const QString elided = status_label_->fontMetrics().elidedText(
+                status_text_, Qt::ElideMiddle, available);
+            if (elided != status_label_->text())
+                status_label_->setText(elided);
+        } else {
+            status_label_->setText(status_text_);
+        }
+    }
+
+    bool eventFilter(QObject* watched, QEvent* event) override
+    {
+        if (watched == status_label_ && event->type() == QEvent::Resize)
+            refreshStatusElide();
+        return QWidget::eventFilter(watched, event);
+    }
+
+    void resizeEvent(QResizeEvent* event) override
+    {
+        QWidget::resizeEvent(event);
+        refreshStatusElide();
+    }
+
     void updateAudioDeviceVisibility()
     {
         const bool visible = input_mode_->currentData().toInt() != 2;
@@ -1109,7 +1152,7 @@ private:
             return false;
         }
         if (notify && status_label_)
-            status_label_->setText(QCoreApplication::translate("ASRTU", "设置已保存"));
+            setStatusText(QCoreApplication::translate("ASRTU", "设置已保存"));
         return true;
     }
 
@@ -1125,6 +1168,7 @@ private:
     QCheckBox* recording_enabled_ = nullptr;
     QTimer* autoSaveTimer_ = nullptr;
     QLabel* status_label_ = nullptr;
+    QString status_text_;
 };
 }
 

--- a/libs/common/version.h
+++ b/libs/common/version.h
@@ -1,0 +1,8 @@
+#pragma once
+
+// ASRTU_VERSION is injected by CMake from the project VERSION
+// (see CMakeLists.txt: project(ASRTU1Qt VERSION ...)).  The fallback keeps
+// translation-unit-only builds working when the macro is not defined.
+#ifndef ASRTU_VERSION
+#define ASRTU_VERSION "unknown"
+#endif


### PR DESCRIPTION
## Summary

- **#8**: Show the application version (injected from CMake PROJECT_VERSION as ASRTU_VERSION) in the launcher, demodulator and satellite-tracker window titles, so screenshots and support questions identify the build.
- **#16**: Replaying a recording with a very long filename no longer stretches the launcher window: the status label keeps a zero minimum width, grows with the layout, and renders long text with a middle ellipsis recomputed on resize.

Closes #8
Closes #16